### PR TITLE
composer: min PHP 5.4 added

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "psr-4": { "Entity\\": "examples/entities/", "SampleSpecs\\": "examples/specs/" }
     },
     "require": {
+        "php": ">=5.4",
         "hoa/ruler": "~1.0",
         "symfony/property-access": "~2.3"
     },


### PR DESCRIPTION
This version is min in Travis, so I suppose it's min required, thus should be mentioned in `composer.json`.
