### PR TITLE
Configure Composer bin-dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /composer.lock
 /vendor
+/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ before_script:
     - composer install --prefer-source
 
 script:
-    - vendor/bin/phpspec run -f dot
+    - bin/phpspec run -f dot

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
     "autoload-dev": {
         "psr-4": { "Entity\\": "examples/entities/", "SampleSpecs\\": "examples/specs/" }
     },
+    "config": {
+        "bin-dir": "bin/"
+    },
     "require": {
         "php": ">=5.4",
         "hoa/ruler": "~1.0",


### PR DESCRIPTION
This pull request configures the Composer bin-dir, so you can type bin/phpspec instead of vendor/phpspec/phpspec/bin/phpspec in order to run tests.

Also, it adds PHPStorm's .idea directory to .gitignore.
