### PR TITLE
Fix phpSpec configuration because of coduo/phpspec-data-provider-extension BC break

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "illuminate/database": "~5.0",
 
         "mikey179/vfsStream": "~1.4",
-        "coduo/phpspec-data-provider-extension": "~1.0",
+        "coduo/phpspec-data-provider-extension": "~1.0.2",
         "phpspec/phpspec": "~2.0",
 
         "hoa/bench": "~2.0",

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -1,3 +1,3 @@
 formatter.name: dot
 extensions:
-  - Coduo\PhpSpec\DataProvider\DataProviderExtension
+  - Coduo\PhpSpec\DataProviderExtension


### PR DESCRIPTION
The latest version of [coduo/phpspec-data-provider-extension](https://github.com/coduo/phpspec-data-provider-extension) broke BC: https://github.com/coduo/phpspec-data-provider-extension/commit/f6e33b689f3c3e9c91392130ba1257101b210a2e
