### PR TITLE
Use the latest hoa/ruler version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "require": {
         "php": ">=5.5",
-        "hoa/ruler": "~1.0",
+        "hoa/ruler": "~2.0",
         "symfony/property-access": "~2.3|~3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Because it's lighter, faster and reduce number of code at load time. See http://blog.hoa-project.net/posts/36-the-nucleus-release-series.html for more details.
