### PR TITLE
Add Doctrine Obscure Alias Support

### DIFF
--- a/src/Executor/DoctrineQueryBuilder/AutoJoin.php
+++ b/src/Executor/DoctrineQueryBuilder/AutoJoin.php
@@ -77,6 +77,11 @@ class AutoJoin
             return $table;
         }
 
+        // the table name is a known alias that was assigned an obscure alias in the query builder
+        if (in_array($fullPropertyPath, $this->knownAliases, true)) {
+            return array_search($fullPropertyPath, $this->knownAliases, true);
+        }
+
         // otherwise the table should have automatically been joined, so we use our table prefix
         if (isset($this->knownAliases[self::ALIAS_PREFIX.$table])) {
             return self::ALIAS_PREFIX . $table;
@@ -99,6 +104,9 @@ class AutoJoin
             // the table name is a known alias (already join for instance) so we
             // don't need to do anything.
             $alias = $embeddableTable;
+        } elseif (in_array($embeddableTable, $this->knownAliases, true)) {
+            // the table name is a known alias that was assigned an obscure alias in the query builder
+            $alias = array_search($embeddableTable, $this->knownAliases, true);
         } elseif (array_key_exists(self::ALIAS_PREFIX . $embeddableTable, $this->knownAliases)) {
             // otherwise the table should have automatically been joined, so we use our table prefix.
             $alias = self::ALIAS_PREFIX . $embeddableTable;


### PR DESCRIPTION
Hello,

I'm having an issue with RulerZ when attempting to auto-join tables with obscure aliases. In particular, when an association is assigned an alias in the query builder that does not match the name of the association.

This query builder works fine in the current version (0.19.1) of RulerZ:

``` php
$entity_manager->createQueryBuilder()
    ->select('permission')
    ->from('Permission', 'permission')
    ->innerJoin('permission.entitlement', 'entitlement')
    ->innerJoin('entitlement.product', 'product');
```

However, this query builder throws a RuntimeException: Could not automatically join table "product"

``` php
$entity_manager->createQueryBuilder()
    ->select('permission')
    ->from('Permission', 'permission')
    ->innerJoin('permission.entitlement', 'entitlement')
    ->innerJoin('entitlement.product', 'product_1');
```

In both cases, my specification rule looks like this:

``` php
public function getRule()
{
    return 'entitlement.product.id = :entitlement_product_id';
}
```

Do you have any thoughts on this issue? My fix appears to revolve it.
