### PR TITLE
Fix positional parameters breaking Doctrine ORM

### DIFF
--- a/src/Parser/HoaParser.php
+++ b/src/Parser/HoaParser.php
@@ -169,8 +169,8 @@ class HoaParser implements Parser, Visitor\Visit
 
                     case 'positional_parameter':
                         $index = $this->nextParameterIndex++;
-
-                        return new Model\Parameter($index);
+                        $prefix = '_';
+                        return new Model\Parameter($prefix.$index);
 
                     case 'true':
                         return true;

--- a/src/RulerZ.php
+++ b/src/RulerZ.php
@@ -53,6 +53,7 @@ class RulerZ
      */
     public function applyFilter($target, $rule, array $parameters = [], array $executionContext = [])
     {
+        $parameters = $this->normalizeParameters($parameters);
         $targetCompiler = $this->findTargetCompiler($target, CompilationTarget::MODE_APPLY_FILTER);
         $executor       = $this->compiler->compile($rule, $targetCompiler);
 
@@ -72,6 +73,7 @@ class RulerZ
      */
     public function filter($target, $rule, array $parameters = [], array $executionContext = [])
     {
+        $parameters = $this->normalizeParameters($parameters);
         $targetCompiler = $this->findTargetCompiler($target, CompilationTarget::MODE_FILTER);
         $executor       = $this->compiler->compile($rule, $targetCompiler);
 
@@ -160,5 +162,25 @@ class RulerZ
         }
 
         throw new TargetUnsupportedException('The given target is not supported.');
+    }
+    
+    /**
+     * Ensures positional parameters are prefixed with a string
+     * 
+     * @param array $params The parameters to normalize
+     * 
+     * @return array
+     */
+    private function normalizeParameters(array $params) 
+    {
+        $normalizedParams = [];
+        $prefix = '_';
+        foreach ($params as $key => $value) {
+            if (is_int($key)) {
+                $key = $prefix.(string) $key;
+            }
+            $normalizedParams[$key] = $value;
+        }
+        return $normalizedParams;
     }
 }


### PR DESCRIPTION
Not sure when this broke, but latest Doctrine ORM chokes when using positional parameters.

Problem seems to be Doctrine DQL does not support named parameters that begin with an integer. So when Rulerz converts positional params to :1, :2 etc, these cause an error.

This patch prefixes these params with an "_" so that the query succeeds.
