### PR TITLE
InnerObjet in Elasticsearch

### DIFF
--- a/src/Grammar.pp
+++ b/src/Grammar.pp
@@ -65,7 +65,7 @@
 %token  dot           \.
 
 %token  positional_parameter \?
-%token  named_parameter      :[a-z-A-Z0-9_]+
+%token  named_parameter      :[a-z-A-Z0-9_.]+
 
 %token  identifier    [^\s\(\)\[\],\.]+
 


### PR DESCRIPTION
Fix : Cannot use dot for Parameter with InnerObject / Nested in elasticsearch

https://www.elastic.co/guide/en/elasticsearch/guide/current/nested-query.html
