### PR TITLE
Eloquent visitor to enable use of eloquent builder

### DIFF
--- a/src/Executor/Eloquent/FilterTrait.php
+++ b/src/Executor/Eloquent/FilterTrait.php
@@ -17,7 +17,7 @@ trait FilterTrait
     public function applyFilter($target, array $parameters, array $operators, ExecutionContext $context)
     {
         /** @var QueryBuilder $query */
-        $query = !$target instanceof QueryBuilder ? $target->getQuery() : $target;
+        $query = !$target instanceof QueryBuilder && !$this->allowEloquentBuilderAsQuery ? $target->getQuery() : $target;
         $sql   = $this->execute($target, $operators, $parameters);
 
         $query->whereRaw($sql, $parameters);

--- a/src/Target/Eloquent/Eloquent.php
+++ b/src/Target/Eloquent/Eloquent.php
@@ -2,6 +2,7 @@
 
 namespace RulerZ\Target\Eloquent;
 
+use RulerZ\Compiler\Context;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 
@@ -9,6 +10,25 @@ use RulerZ\Target\AbstractSqlTarget;
 
 class Eloquent extends AbstractSqlTarget
 {
+    /**
+     * Allow eloquent builder as query.
+     *
+     * @var bool
+     */
+    protected $allowEloquentBuilderAsQuery = false;
+
+    /**
+     * Constructor.
+     *
+     * @param bool            $allowEloquentBuilderAsQuery Whether to allow the execution target to be eloquent builder instead of query builder.
+     */
+    public function __construct($allowEloquentBuilderAsQuery = false)
+    {
+        parent::__construct();
+
+        $this->allowEloquentBuilderAsQuery = (bool) $allowEloquentBuilderAsQuery;
+    }
+
     /**
      * @inheritDoc
      */
@@ -26,5 +46,13 @@ class Eloquent extends AbstractSqlTarget
             '\RulerZ\Executor\Eloquent\FilterTrait',
             '\RulerZ\Executor\Polyfill\FilterBasedSatisfaction',
         ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function createVisitor(Context $context)
+    {
+        return new EloquentVisitor($context, $this->getOperators(), $this->allowStarOperator, $this->allowEloquentBuilderAsQuery);
     }
 }

--- a/src/Target/Eloquent/EloquentVisitor.php
+++ b/src/Target/Eloquent/EloquentVisitor.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace RulerZ\Target\Eloquent;
+
+use Hoa\Ruler\Model as AST;
+
+use RulerZ\Compiler\Context;
+use RulerZ\Target\GenericSqlVisitor;
+use RulerZ\Target\Operators\Definitions as OperatorsDefinitions;
+
+class EloquentVisitor extends GenericSqlVisitor
+{
+    /**
+     * Allow eloquent builder as query.
+     *
+     * @var bool
+     */
+    protected $allowEloquentBuilderAsQuery = false;
+
+    public function __construct(
+        Context $context,
+        OperatorsDefinitions $operators,
+        $allowStarOperator = true,
+        $allowEloquentBuilderAsQuery = false
+    ) {
+        parent::__construct($context, $operators, $allowStarOperator);
+
+        $this->allowEloquentBuilderAsQuery = (bool) $allowEloquentBuilderAsQuery;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getCompilationData()
+    {
+        return [
+            'allowEloquentBuilderAsQuery ' => $this->allowEloquentBuilderAsQuery,
+        ];
+    }
+}

--- a/tests/stub/Executor/EloquentExecutorStub.php
+++ b/tests/stub/Executor/EloquentExecutorStub.php
@@ -7,6 +7,7 @@ use RulerZ\Executor\Eloquent\FilterTrait;
 class EloquentExecutorStub
 {
     public static $executeReturn;
+    protected $allowEloquentBuilderAsQuery = false;
 
     use FilterTrait;
 


### PR DESCRIPTION
Eloquent visitor to enable use of eloquent builder instead of only using query builder. Eloquent builder is helpful when we want results return to be hydrated in model objects and use this objects later.