### PR TITLE
Preserve eloquent positional parameters

### DIFF
--- a/src/Target/Eloquent/Eloquent.php
+++ b/src/Target/Eloquent/Eloquent.php
@@ -18,13 +18,23 @@ class Eloquent extends AbstractSqlTarget
     protected $allowEloquentBuilderAsQuery = false;
 
     /**
+     * Preserve positional parameters.
+     *
+     * @var bool
+     */
+    protected $preservePositionalParameters = false;
+
+    /**
      * @param bool $allowEloquentBuilderAsQuery Whether to allow the execution target to be eloquent builder instead of query builder.
      */
-    public function __construct($allowEloquentBuilderAsQuery = false)
-    {
+    public function __construct(
+        $allowEloquentBuilderAsQuery = false,
+        $preservePositionalParameters = false
+    ) {
         parent::__construct();
 
         $this->allowEloquentBuilderAsQuery = (bool) $allowEloquentBuilderAsQuery;
+        $this->preservePositionalParameters = (bool) $preservePositionalParameters;
     }
 
     /**
@@ -51,6 +61,12 @@ class Eloquent extends AbstractSqlTarget
      */
     protected function createVisitor(Context $context)
     {
-        return new EloquentVisitor($context, $this->getOperators(), $this->allowStarOperator, $this->allowEloquentBuilderAsQuery);
+        return new EloquentVisitor(
+            $context,
+            $this->getOperators(),
+            $this->allowStarOperator,
+            $this->allowEloquentBuilderAsQuery,
+            $this->preservePositionalParameters
+        );
     }
 }

--- a/src/Target/Eloquent/EloquentVisitor.php
+++ b/src/Target/Eloquent/EloquentVisitor.php
@@ -2,6 +2,7 @@
 
 namespace RulerZ\Target\Eloquent;
 
+use RulerZ\Model;
 use RulerZ\Compiler\Context;
 use RulerZ\Target\GenericSqlVisitor;
 use RulerZ\Target\Operators\Definitions as OperatorsDefinitions;
@@ -15,11 +16,35 @@ class EloquentVisitor extends GenericSqlVisitor
      */
     protected $allowEloquentBuilderAsQuery = false;
 
-    public function __construct(Context $context, OperatorsDefinitions $operators, $allowStarOperator = true, $allowEloquentBuilderAsQuery = false)
-    {
+    /**
+     * Preserve positional parameters.
+     *
+     * @var bool
+     */
+    protected $preservePositionalParameters = false;
+
+    /**
+     * @param bool $allowEloquentBuilderAsQuery Whether to allow the execution target to be eloquent builder instead of query builder.
+     */
+    public function __construct(
+        Context $context,
+        OperatorsDefinitions $operators,
+        $allowStarOperator = true,
+        $allowEloquentBuilderAsQuery = false,
+        $preservePositionalParameters = false
+    ) {
         parent::__construct($context, $operators, $allowStarOperator);
 
         $this->allowEloquentBuilderAsQuery = (bool) $allowEloquentBuilderAsQuery;
+        $this->preservePositionalParameters = (bool) $preservePositionalParameters;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function visitParameter(Model\Parameter $element, &$handle = null, $eldnah = null)
+    {
+        return $this->preservePositionalParameters ? '?' : ':'.$element->getName();
     }
 
     /**


### PR DESCRIPTION
Preserve eloquent positional parameters resolve issue when we are using additional raw queries with bindings in eloquent.