### PR TITLE
Expose the object contained in ObjectContext

### DIFF
--- a/src/Context/ObjectContext.php
+++ b/src/Context/ObjectContext.php
@@ -28,6 +28,16 @@ class ObjectContext implements \ArrayAccess
     }
 
     /**
+     * Returns the object of the context.
+     *
+     * @return mixed
+     */
+    public function getObject()
+    {
+        return $this->object;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function offsetGet($id)


### PR DESCRIPTION
We have come custom operators which need to access the object contained in ObjectContext. This PR exposes the object through `getObject`.