### PR TITLE
ObjectContext returns array "as is"

### DIFF
--- a/src/Context/ObjectContext.php
+++ b/src/Context/ObjectContext.php
@@ -44,7 +44,7 @@ class ObjectContext implements \ArrayAccess
     {
         $value = $this->accessor->getValue($this->object, $id);
 
-        if (is_scalar($value)) {
+        if (is_scalar($value) || is_array($value)) {
             return $value;
         }
 


### PR DESCRIPTION
Hi,

I'm trying to upgrade from `0.17.x` to `0.19.3` and my custom operator `intersects` is not working:
```php
class ArrayIntersects
{
    public function __invoke($a, $b)
    {
        return sprintf('!empty(array_intersect(%s, %s))', $a, $b);
    }
}
```

I have this error: `Warning: array_intersect(): Argument #1 is not an array /tmp/rulerz_executor_f2795b9b:16`.
My array is wrapped by a `ObjectContext`. Maybe it shouldn't?

This patch seems to fix the problem.

So, what do you think? :thinking: 
