### PR TITLE
Fix compilation when multilines rule is provided

### DIFF
--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -62,6 +62,8 @@ class Compiler
             $extraCode .= sprintf('private $%s = %s;'.PHP_EOL, $key, var_export($value, true));
         }
 
+        $commentedRule = str_replace(PHP_EOL, PHP_EOL . '    // ', $rule);
+
         return <<<EXECUTOR
 namespace RulerZ\Compiled\Executor;
 
@@ -73,7 +75,7 @@ class {$context['executor_classname']} implements Executor
 
     $extraCode
 
-    // $rule
+    // $commentedRule
     protected function execute(\$target, array \$operators, array \$parameters)
     {
         return {$executorModel->getCompiledRule()};


### PR DESCRIPTION
For readability i wanted to write my rules on multiple lines. The compiler didn't like that idea because it [writes the rule in a PHP comment](https://github.com/K-Phoen/rulerz/blob/master/src/Compiler/Compiler.php#L76) that would break PHP when there is an EOL.

I just `str_replace` the `PHP_EOL` on the rule to handle this scenario.