### PR TITLE
Prevent ObjectContext from wrapping nulls.

### DIFF
--- a/src/Context/ObjectContext.php
+++ b/src/Context/ObjectContext.php
@@ -44,7 +44,7 @@ class ObjectContext implements \ArrayAccess
     {
         $value = $this->accessor->getValue($this->object, $id);
 
-        if (is_scalar($value)) {
+        if (is_scalar($value) || $value === null) {
             return $value;
         }
 

--- a/tests/spec/RulerZ/Context/ObjectContextSpec.php
+++ b/tests/spec/RulerZ/Context/ObjectContextSpec.php
@@ -6,25 +6,32 @@ use PhpSpec\ObjectBehavior;
 
 class ObjectContextSpec extends ObjectBehavior
 {
-    function let(\stdClass $object)
+    public function let(\stdClass $object)
     {
         $this->beConstructedWith($object);
         $this->shouldImplement('ArrayAccess');
     }
 
-    function it_is_initializable()
+    public function it_is_initializable()
     {
         $this->shouldHaveType('RulerZ\Context\ObjectContext');
     }
 
-    function it_allows_property_access_through_offset($object)
+    public function it_allows_property_access_through_offset($object)
     {
         $object->property = 42;
 
         $this['property']->shouldReturn(42);
     }
 
-    function it_allows_testing_property_existence($object)
+    public function it_doesnt_wrap_nulls_with_self($object)
+    {
+        $object->property = null;
+
+        $this['property']->shouldReturn(null);
+    }
+
+    public function it_allows_testing_property_existence($object)
     {
         $object->property = 42;
 
@@ -32,12 +39,12 @@ class ObjectContextSpec extends ObjectBehavior
         $this->offsetExists('non_existent_property')->shouldReturn(false);
     }
 
-    function it_forbids_setting_properties()
+    public function it_forbids_setting_properties()
     {
         $this->shouldThrow('\RuntimeException')->duringOffsetSet('foo', 'bar');
     }
 
-    function it_forbids_unsetting_properties()
+    public function it_forbids_unsetting_properties()
     {
         $this->shouldThrow('\RuntimeException')->duringOffsetUnset('foo');
     }


### PR DESCRIPTION
Fixes #75 