### PR TITLE
Fixes a bug where you cannot use a runtime operator in a SQL query

### DIFF
--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -4,6 +4,7 @@ namespace RulerZ\Compiler;
 
 use RulerZ\Executor\Executor;
 use RulerZ\Parser\Parser;
+use RulerZ\Target\Operators\CompileTimeOperator;
 
 class Compiler
 {
@@ -63,6 +64,8 @@ class Compiler
         }
 
         $commentedRule = str_replace(PHP_EOL, PHP_EOL.'    // ', $rule);
+        $compiledRule = $executorModel->getCompiledRule();
+        $escapedRule = is_string($compiledRule) ? $compiledRule : $compiledRule->format(false);
 
         return <<<EXECUTOR
 namespace RulerZ\Compiled\Executor;
@@ -78,7 +81,7 @@ class {$context['executor_classname']} implements Executor
     // $commentedRule
     protected function execute(\$target, array \$operators, array \$parameters)
     {
-        return {$executorModel->getCompiledRule()};
+        return {$escapedRule};
     }
 }
 EXECUTOR;

--- a/src/Target/GenericSqlVisitor.php
+++ b/src/Target/GenericSqlVisitor.php
@@ -7,6 +7,7 @@ use Hoa\Ruler\Model as AST;
 use RulerZ\Compiler\Context;
 use RulerZ\Exception\OperatorNotFoundException;
 use RulerZ\Model;
+use RulerZ\Target\Operators\CompileTimeOperator;
 use RulerZ\Target\Operators\Definitions as OperatorsDefinitions;
 
 /**
@@ -46,7 +47,13 @@ class GenericSqlVisitor extends GenericVisitor
     {
         $sql = parent::visitModel($element, $handle, $eldnah);
 
-        return '"'.$sql.'"';
+        if (is_string($sql)) {
+            return '"' . $sql . '"';
+        } elseif ($sql instanceof CompileTimeOperator) {
+            return '"' . $sql->format(true) . '"';
+        } else {
+            return $sql->format(false);
+        }
     }
 
     /**

--- a/src/Target/GenericVisitor.php
+++ b/src/Target/GenericVisitor.php
@@ -8,6 +8,8 @@ use Hoa\Visitor\Element as VisitorElement;
 use RulerZ\Compiler\RuleVisitor;
 use RulerZ\Exception\OperatorNotFoundException;
 use RulerZ\Model;
+use RulerZ\Target\Operators\CompileTimeOperator;
+use RulerZ\Target\Operators\RuntimeOperator;
 use RulerZ\Target\Operators\Definitions as OperatorsDefinitions;
 
 /**
@@ -114,12 +116,12 @@ abstract class GenericVisitor implements RuleVisitor
         if ($this->operators->hasInlineOperator($operatorName)) {
             $callable = $this->operators->getInlineOperator($operatorName);
 
-            return call_user_func_array($callable, $arguments);
+            return new CompileTimeOperator(
+                call_user_func_array($callable, $arguments)
+            );
         }
 
-        $inlinedArguments = empty($arguments) ? '' : ', '.implode(', ', $arguments);
-
         // or defer it.
-        return sprintf('call_user_func($operators["%s"]%s)', $operatorName, $inlinedArguments);
+        return new RuntimeOperator(sprintf('$operators["%s"]', $operatorName), $arguments);
     }
 }

--- a/src/Target/Native/NativeOperators.php
+++ b/src/Target/Native/NativeOperators.php
@@ -3,6 +3,7 @@
 namespace RulerZ\Target\Native;
 
 use RulerZ\Target\Operators\Definitions;
+use RulerZ\Target\Operators\OperatorTools;
 
 class NativeOperators
 {
@@ -13,37 +14,37 @@ class NativeOperators
     {
         $defaultInlineOperators = [
             'and' => function ($a, $b) {
-                return sprintf('(%s && %s)', $a, $b);
+                return sprintf('(%s)', OperatorTools::inlineMixedInstructions([$a, $b], '&&', false));
             },
             'or' => function ($a, $b) {
-                return sprintf('(%s || %s)', $a, $b);
+                return sprintf('(%s)', OperatorTools::inlineMixedInstructions([$a, $b], '||', false));
             },
             'not' => function ($a) {
-                return sprintf('!(%s)', $a);
+                return sprintf('!(%s)', OperatorTools::inlineMixedInstructions([$a], null, false));
             },
             '=' => function ($a, $b) {
-                return sprintf('%s == %s', $a, $b);
+                return OperatorTools::inlineMixedInstructions([$a, $b], '==', false);
             },
             'is' => function ($a, $b) {
-                return sprintf('%s === %s', $a, $b);
+                return OperatorTools::inlineMixedInstructions([$a, $b], '===', false);
             },
             '!=' => function ($a, $b) {
-                return sprintf('%s != %s', $a, $b);
+                return OperatorTools::inlineMixedInstructions([$a, $b], '!=', false);
             },
             '>' => function ($a, $b) {
-                return sprintf('%s > %s', $a, $b);
+                return OperatorTools::inlineMixedInstructions([$a, $b], '>', false);
             },
             '>=' => function ($a, $b) {
-                return sprintf('%s >= %s', $a, $b);
+                return OperatorTools::inlineMixedInstructions([$a, $b], '>=', false);
             },
             '<' => function ($a, $b) {
-                return sprintf('%s < %s', $a, $b);
+                return OperatorTools::inlineMixedInstructions([$a, $b], '<', false);
             },
             '<=' => function ($a, $b) {
-                return sprintf('%s <= %s', $a, $b);
+                return OperatorTools::inlineMixedInstructions([$a, $b], '<=', false);
             },
             'in' => function ($a, $b) {
-                return sprintf('in_array(%s, %s)', $a, $b);
+                return sprintf('in_array(%s)', OperatorTools::inlineMixedInstructions([$a, $b], ',', false));
             },
         ];
 

--- a/src/Target/Operators/CompileTimeOperator.php
+++ b/src/Target/Operators/CompileTimeOperator.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace RulerZ\Target\Operators;
+
+class CompileTimeOperator
+{
+    /**
+     * @var string
+     */
+    private $compiledOperator;
+
+    public function __construct($compiled)
+    {
+        $this->compiledOperator = $compiled;
+    }
+
+    public function format($shouldBreakString)
+    {
+        return $this->compiledOperator;
+    }
+}

--- a/src/Target/Operators/GenericSqlDefinitions.php
+++ b/src/Target/Operators/GenericSqlDefinitions.php
@@ -11,37 +11,45 @@ class GenericSqlDefinitions
     {
         $defaultInlineOperators = [
             'and' => function ($a, $b) {
-                return sprintf('(%s AND %s)', $a, $b);
+                return sprintf('(%s)', OperatorTools::inlineMixedInstructions([$a, $b], 'AND'));
             },
             'or' => function ($a, $b) {
-                return sprintf('(%s OR %s)', $a, $b);
+                return sprintf('(%s)', OperatorTools::inlineMixedInstructions([$a, $b], 'OR'));
             },
             'not' => function ($a) {
-                return sprintf('NOT (%s)', $a);
+                return sprintf('NOT (%s)', OperatorTools::inlineMixedInstructions([$a]));
             },
             '=' => function ($a, $b) {
-                return sprintf('%s = %s', $a, $b);
+                return OperatorTools::inlineMixedInstructions([$a, $b], '=');
             },
             '!=' => function ($a, $b) {
-                return sprintf('%s != %s', $a, $b);
+                return OperatorTools::inlineMixedInstructions([$a, $b], '!=');
             },
             '>' => function ($a, $b) {
-                return sprintf('%s > %s', $a, $b);
+                return OperatorTools::inlineMixedInstructions([$a, $b], '>');
             },
             '>=' => function ($a, $b) {
-                return sprintf('%s >= %s', $a, $b);
+                return OperatorTools::inlineMixedInstructions([$a, $b], '>=');
             },
             '<' => function ($a, $b) {
-                return sprintf('%s < %s', $a, $b);
+                return OperatorTools::inlineMixedInstructions([$a, $b], '<');
             },
             '<=' => function ($a, $b) {
-                return sprintf('%s <= %s', $a, $b);
+                return OperatorTools::inlineMixedInstructions([$a, $b], '<=');
             },
             'in' => function ($a, $b) {
-                return sprintf('%s IN %s', $a, $b[0] === '(' ? $b : '('.$b.')');
+                if ($b[0] === '(') {
+                    return OperatorTools::inlineMixedInstructions([$a, $b], 'IN');
+                } else {
+                    return sprintf(
+                        '%s IN (%s)',
+                        OperatorTools::inlineMixedInstructions([$a]),
+                        OperatorTools::inlineMixedInstructions([$b])
+                    );
+                }
             },
             'like' => function ($a, $b) {
-                return sprintf('%s LIKE %s', $a, $b);
+                return OperatorTools::inlineMixedInstructions([$a, $b], 'LIKE');
             },
         ];
 

--- a/src/Target/Operators/OperatorTools.php
+++ b/src/Target/Operators/OperatorTools.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace RulerZ\Target\Operators;
+
+class OperatorTools
+{
+    public static function inlineMixedInstructions(array $instructions, $operator = null, $useStringBreakingLogic = true)
+    {
+        $elements = [];
+
+        foreach ($instructions as $instruction) {
+            if ($instruction instanceof RuntimeOperator) {
+                $elements[] = $instruction->format($useStringBreakingLogic);
+            } else if ($instruction instanceof CompileTimeOperator) {
+                $elements[] = sprintf('%s', $instruction->format(false));
+            } else {
+                $elements[] = sprintf('%s', $instruction);
+            }
+        }
+
+        if (null === $operator) {
+            return join('', $elements);
+        } else {
+            return join(' '.$operator.' ', $elements);
+        }
+    }
+}

--- a/src/Target/Operators/RuntimeOperator.php
+++ b/src/Target/Operators/RuntimeOperator.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace RulerZ\Target\Operators;
+
+class RuntimeOperator
+{
+    /**
+     * @var string
+     */
+    private $callable;
+
+    /**
+     * @var array
+     */
+    private $arguments;
+
+    public function __construct($callable, $arguments)
+    {
+        $this->callable = $callable;
+        $this->arguments = $arguments;
+    }
+
+    public function format($shouldBreakString)
+    {
+        $formattedArguments = join(',', array_map(function ($argument) {
+            if ('$' === $argument[0]) {
+                return $argument;
+            } else {
+                return sprintf('"%s"', $argument);
+            }
+        }, $this->arguments));
+
+        if (true === $shouldBreakString) {
+            return sprintf(
+                '".call_user_func_array(%s, [%s])."',
+                $this->callable,
+                $formattedArguments
+            );
+        } else {
+            return sprintf(
+                'call_user_func_array(%s, [%s])',
+                $this->callable,
+                $formattedArguments
+            );
+        }
+    }
+}


### PR DESCRIPTION
This attempts to fix the bug documented in #40. As you stated, it wasn't a trivial fix and our fix is, unfortunately, a bit disruptive.

This introduces a few new objects to track what type of operators are being created so that they can be formatted correctly when they are written out to a cache. Breaking out of strings is a bit messy but it was the most straightforward method we could find to solve the issue.

We've only confirmed that the native and DoctrineORM targets work right now as that is what we use in our project. I'd like feedback on our approach but we do intend on fixing the other targets and tests to work.
