### PR TITLE
Pass the Executor instance to operators

### DIFF
--- a/src/Target/GenericVisitor.php
+++ b/src/Target/GenericVisitor.php
@@ -110,6 +110,8 @@ abstract class GenericVisitor implements RuleVisitor
             return $argument->accept($this, $handle, $eldnah);
         }, $element->getArguments());
 
+        $arguments[] = '$this';
+
         // and either inline the operator call
         if ($this->operators->hasInlineOperator($operatorName)) {
             $callable = $this->operators->getInlineOperator($operatorName);


### PR DESCRIPTION
We have a couple of instances where we need extra information in our operators and the ability to manipulate the parameters (add/remove placeholders in the case of SQL operators). We've accomplished this by using a custom trait but as it is right now, we cannot access anything outside of the operator.

This PR passes the instance of the Executor to the operator as the last parameter, as such this should be BC as existing operators will simply ignore it.