### PR TITLE
Generalizes DoctrineAutoJoin

### DIFF
--- a/src/Target/DoctrineORM/DoctrineAutoJoin.php
+++ b/src/Target/DoctrineORM/DoctrineAutoJoin.php
@@ -55,13 +55,8 @@ class DoctrineAutoJoin
         return $this->detectedJoins;
     }
 
-    public function buildAccessPath(AST\Bag\Context $element)
+    public function buildAccessPath(array $dimensionNames)
     {
-        $dimensionNames = array_map(function ($dimension) {
-            return $dimension[1];
-        }, $element->getDimensions());
-        array_unshift($dimensionNames, $element->getId());
-
         $currentEntity = current($this->rootEntities);
         $lastAlias = key($this->aliasMap);
 

--- a/src/Target/DoctrineORM/DoctrineAutoJoin.php
+++ b/src/Target/DoctrineORM/DoctrineAutoJoin.php
@@ -3,7 +3,6 @@
 namespace RulerZ\Target\DoctrineORM;
 
 use Doctrine\ORM\EntityManagerInterface as EntityManager;
-use Hoa\Ruler\Model as AST;
 
 class DoctrineAutoJoin
 {
@@ -69,6 +68,7 @@ class DoctrineAutoJoin
             if (isset($this->aliasMap[$dimension])) {
                 $currentEntity = $this->getEntity($dimension);
                 $lastAlias = $dimension;
+
                 continue;
             }
 
@@ -94,6 +94,7 @@ class DoctrineAutoJoin
 
                 $currentEntity = $association['targetEntity'];
                 $lastAlias = $alias;
+
                 continue;
             }
 
@@ -105,6 +106,7 @@ class DoctrineAutoJoin
 
                 $currentEntity = $embeddableMetadata['class'];
                 $lastAlias = $lastAlias.'.'.$dimension;
+
                 continue;
             }
 

--- a/src/Target/DoctrineORM/DoctrineORMVisitor.php
+++ b/src/Target/DoctrineORM/DoctrineORMVisitor.php
@@ -38,7 +38,12 @@ class DoctrineORMVisitor extends GenericSqlVisitor
      */
     public function visitAccess(AST\Bag\Context $element, &$handle = null, $eldnah = null)
     {
-        return $this->autoJoin->buildAccessPath($element);
+        $dimensionNames = array_map(function ($dimension) {
+            return $dimension[1];
+        }, $element->getDimensions());
+        array_unshift($dimensionNames, $element->getId());
+
+        return $this->autoJoin->buildAccessPath($dimensionNames);
     }
 
     /**


### PR DESCRIPTION
This PR generalizes `DoctrineAutoJoin` it can be used outside of RulerZ.

We have a use case where we need to perform joins using dotted notation (e.g. someRelation.x.y.property). The `DoctrineAutoJoin` class does this for us but only accepts a `Context` as an argument.