### PR TITLE
Fix doc examples with up to date namespaces

### DIFF
--- a/doc/cookbooks/doctrine_orm.md
+++ b/doc/cookbooks/doctrine_orm.md
@@ -25,7 +25,7 @@ Once Doctrine is installed and configured we can the RulerZ engine:
 ```php
 $rulerz = new RulerZ(
     $compiler, [
-        new \RulerZ\Compiler\Target\Sql\DoctrineQueryBuilder(), // this line is Doctrine-specific
+        new \RulerZ\Target\DoctrineORM\DoctrineORM(), // this line is Doctrine-specific
         // other compilation targets...
     ]
 );

--- a/doc/cookbooks/elastic_elasticsearch_php.md
+++ b/doc/cookbooks/elastic_elasticsearch_php.md
@@ -27,7 +27,7 @@ Once elastic/elasticsearch-php is installed and configured we can the RulerZ eng
 ```php
 $rulerz = new RulerZ(
     $compiler, [
-        new \RulerZ\Compiler\Target\Elasticsearch\Elasticsearch(), // this line is Elasticsearch-specific
+        new \RulerZ\Target\Elasticsearch\Elasticsearch(), // this line is Elasticsearch-specific
         // other compilation targets...
     ]
 );

--- a/doc/cookbooks/eloquent_orm.md
+++ b/doc/cookbooks/eloquent_orm.md
@@ -22,8 +22,8 @@ Once Eloquent is installed and configured we can the RulerZ engine:
 
 ```php
 $rulerz = new RulerZ(
-    new HoaInterpreter(), [
-        new \RulerZ\Compiler\Target\Sql\Eloquent(), // this line is Eloquent-specific
+    $compiler, [
+        new \RulerZ\Target\Eloquent\Eloquent(), // this line is Eloquent-specific
         // other compilation targets...
     ]
 );

--- a/doc/cookbooks/pomm.md
+++ b/doc/cookbooks/pomm.md
@@ -24,7 +24,7 @@ Once Pomm is installed and configured we can the RulerZ engine:
 ```php
 $rulerz = new RulerZ(
     $compiler, [
-        new \RulerZ\Compiler\Target\Sql\PommVisitor(), // this line is Pomm-specific
+        new \RulerZ\Target\Pomm\Pomm(), // this line is Pomm-specific
         // other compilation targets...
     ]
 );

--- a/doc/cookbooks/ruflin_elastica.md
+++ b/doc/cookbooks/ruflin_elastica.md
@@ -27,7 +27,7 @@ Once ruflin/elastica is installed and configured we can the RulerZ engine:
 ```php
 $rulerz = new RulerZ(
     $compiler, [
-        new \RulerZ\Compiler\Target\Elasticsearch\Elastica(), // this line is Elastica-specific
+        new \RulerZ\Target\Elastica\Elastica(), // this line is Elastica-specific
         // other compilation targets...
     ]
 );

--- a/doc/cookbooks/solarium.md
+++ b/doc/cookbooks/solarium.md
@@ -26,7 +26,7 @@ Once solarium/solarium is installed and configured we can the RulerZ engine:
 ```php
 $rulerz = new RulerZ(
     $compiler, [
-        new \RulerZ\Compiler\Target\Solr\Solarium(), // this line is Solarium-specific
+        new \RulerZ\Target\Solarium\Solarium(), // this line is Solarium-specific
         // other compilation targets...
     ]
 );

--- a/doc/writing_rules.md
+++ b/doc/writing_rules.md
@@ -30,7 +30,7 @@ Enough said, here is the code:
 
 ```php
 use RulerZ\Compiler\Compiler;
-use RulerZ\Compiler\Target;
+use RulerZ\Target;
 use RulerZ\RulerZ;
 
 // compiler
@@ -39,8 +39,8 @@ $compiler = Compiler::create();
 // RulerZ engine
 $rulerz = new RulerZ(
     $compiler, [
-        new Target\Sql\DoctrineQueryBuilder(),
-        new Target\Native([
+        new Target\DoctrineORM\DoctrineORM(),
+        new Target\Native\Native([
             'length' => 'strlen'
         ]),
     ]

--- a/tests/features/bootstrap/BaseContext.php
+++ b/tests/features/bootstrap/BaseContext.php
@@ -35,7 +35,7 @@ abstract class BaseContext implements Context
     /**
      * Returns the compilation target to be tested.
      *
-     * @return \RulerZ\Compiler\Target\CompilationTarget
+     * @return \RulerZ\Compiler\CompilationTarget
      */
     abstract protected function getCompilationTarget();
 


### PR DESCRIPTION
Since compilation targets reorganization, some examples in documentation were outdated. 