### PR TITLE
Allow to compare dates without encapsulate them in ObjectContext

### DIFF
--- a/examples/entities/Doctrine/Player.php
+++ b/examples/entities/Doctrine/Player.php
@@ -45,7 +45,10 @@ class Player
      */
     public $address;
 
-    public function __construct($pseudo, $fullname, $gender, $age, $points, $group = null)
+    /** @var \DateTime */
+    public $birthDate;
+
+    public function __construct($pseudo, $fullname, $gender, $age, $points, $group = null, $birthDate = null)
     {
         $this->pseudo = $pseudo;
         $this->fullname = $fullname;
@@ -53,5 +56,6 @@ class Player
         $this->age = $age;
         $this->points = $points;
         $this->group = $group;
+        $this->birthDate = $birthDate;
     }
 }

--- a/src/Context/ObjectContext.php
+++ b/src/Context/ObjectContext.php
@@ -44,7 +44,7 @@ class ObjectContext implements \ArrayAccess
     {
         $value = $this->accessor->getValue($this->object, $id);
 
-        if (is_scalar($value) || $value === null) {
+        if (is_scalar($value) || $value instanceof \DateTimeInterface || null === $value) {
             return $value;
         }
 

--- a/tests/features/array/FilteringAnArray.feature
+++ b/tests/features/array/FilteringAnArray.feature
@@ -33,3 +33,37 @@ Feature: RulerZ can filter an array
             | pseudo   |
             | Joe      |
             | Margaret |
+
+
+    Scenario: It works with birth date bigger than an other one
+        Given RulerZ is configured
+        And I use the array of objects dataset
+        When I define a birthDate parameter to "2005-01-04"
+        When I filter the dataset with the rule:
+            """
+            birthDate > :birthDate
+            """
+        Then I should have the following results:
+            | pseudo   |
+            | Joe      |
+            | Margaret |
+
+    Scenario: It works with birth date smaller or equal to an other one
+        Given RulerZ is configured
+        And I use the array of objects dataset
+        When I define a birthDate parameter to "2005-01-04"
+        When I filter the dataset with the rule:
+            """
+            birthDate <= :birthDate
+            """
+        Then I should have the following results:
+            | pseudo    |
+            | Bob       |
+            | Ada       |
+            | Kévin     |
+            | Alice     |
+            | Louise    |
+            | Francis   |
+            | John      |
+            | Arthur    |
+            | Moon Moon |

--- a/tests/features/bootstrap/ArrayContext.php
+++ b/tests/features/bootstrap/ArrayContext.php
@@ -64,6 +64,12 @@ class ArrayContext extends BaseContext
             new Group('Estasia'),
         ];
 
+        $birthDates = [
+            new DateTime('2001-01-02'),
+            new DateTime('2005-01-04'),
+            new DateTime('2007-01-07'),
+        ];
+
         $groupsMapping = [
             'Joe' => 2,
             'Bob' => 0,
@@ -87,7 +93,8 @@ class ArrayContext extends BaseContext
                 $data['gender'],
                 $data['age'],
                 $data['points'],
-                $groups[$groupsMapping[$data['pseudo']]]
+                $groups[$groupsMapping[$data['pseudo']]],
+                $birthDates[$groupsMapping[$data['pseudo']]]
             );
         }
 

--- a/tests/features/bootstrap/BaseContext.php
+++ b/tests/features/bootstrap/BaseContext.php
@@ -112,6 +112,15 @@ abstract class BaseContext implements Context
     }
 
     /**
+     * @When I define a birthDate parameter to :date
+     */
+    public function iDefineABirthdateParameterTo($date)
+    {
+        $this->parameters['birthDate'] = new DateTime($date);
+    }
+
+
+    /**
      * @When I use the default execution context
      */
     public function iUseTheDefaultExecutionContext()

--- a/tests/spec/RulerZ/Context/ObjectContextSpec.php
+++ b/tests/spec/RulerZ/Context/ObjectContextSpec.php
@@ -3,6 +3,7 @@
 namespace spec\RulerZ\Context;
 
 use PhpSpec\ObjectBehavior;
+use RulerZ\Context\ObjectContext;
 
 class ObjectContextSpec extends ObjectBehavior
 {
@@ -29,6 +30,20 @@ class ObjectContextSpec extends ObjectBehavior
         $object->property = null;
 
         $this['property']->shouldReturn(null);
+    }
+
+    public function it_should_return_a_new_ObjectContext_when_we_dont_specify_a_property_of_an_object($object)
+    {
+        $object->property = new \stdClass();
+
+        $this['property']->shouldHaveType(ObjectContext::class);
+    }
+
+    public function it_should_return_a_Datetime_object_whithout_an_encapuslation_of_ObjectContext($object)
+    {
+        $object->property = new \DateTime();
+
+        $this['property']->shouldHaveType(\DateTime::class);
     }
 
     public function it_allows_testing_property_existence($object)


### PR DESCRIPTION
We couldn't compare 2 dates in rulerz rules because they are encapsulated in the ObjectContext class. I did a fix for that.