### PR TITLE
Force Elasticsearch 2.3 in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-sudo: false
+sudo: required
 
 cache:
     directories:
@@ -25,6 +25,8 @@ before_install:
     - phpenv config-rm xdebug.ini || true
     - composer self-update
     - if [ "$TRAVIS_PHP_VERSION" = "7.0" ]; then composer require --dev --no-update kphoen/rusty dev-master; fi
+    - curl -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.0/elasticsearch-2.3.0.deb && sudo dpkg -i --force-confnew elasticsearch-2.3.0.deb && sudo service elasticsearch restart
+
 
 install:
     - composer install --optimize-autoloader --no-interaction

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ docker_start: elasticsearch_start postgres_start solr_start
 docker_stop: elasticsearch_stop postgres_stop solr_stop
 
 elasticsearch_start:
-	docker run -d -p 9200:9200 --name es-rulerz elasticsearch:1.7
+	docker run -d -p 9200:9200 --name es-rulerz elasticsearch:2.4
 
 elasticsearch_stop:
 	docker rm -f es-rulerz


### PR DESCRIPTION
Tests are currently broken on travis-ci because they use a recent version of Elasticsearch.
It looks like the way to create mappings has changed, and maybe the queries generated by rulerz aren't valid anymore.