### PR TITLE
DoctrineAutoJoin uses differing entities when restoring existing aliases and saving new ones

### DIFF
--- a/src/Target/DoctrineORM/DoctrineAutoJoin.php
+++ b/src/Target/DoctrineORM/DoctrineAutoJoin.php
@@ -79,22 +79,23 @@ class DoctrineAutoJoin
                 /** @var \Doctrine\ORM\Mapping\ClassMetadataInfo $classMetadata */
                 $classMetadata = $this->em->getClassMetadata($currentEntity);
                 $association = $classMetadata->getAssociationMapping($dimension);
+                $targetEntity = $association['targetEntity'];
 
-                if (!isset($this->knownEntities[$currentEntity], $this->knownEntities[$currentEntity][$association['fieldName']])) {
+                if (!isset($this->knownEntities[$targetEntity], $this->knownEntities[$targetEntity][$association['fieldName']])) {
                     $alias = sprintf('_%d_%s', count($this->knownEntities, COUNT_RECURSIVE), $dimension);
 
-                    $this->saveAlias($currentEntity, $association['fieldName'], $alias);
+                    $this->saveAlias($targetEntity, $association['fieldName'], $alias);
 
                     $this->detectedJoins[] = [
                         'root' => $lastAlias,
                         'column' => $dimension,
-                        'as' => $alias = $this->getAlias($currentEntity, $association['fieldName']),
+                        'as' => $alias = $this->getAlias($targetEntity, $association['fieldName']),
                     ];
                 } else {
-                    $alias = $this->getAlias($currentEntity, $association['fieldName']);
+                    $alias = $this->getAlias($targetEntity, $association['fieldName']);
                 }
 
-                $currentEntity = $association['targetEntity'];
+                $currentEntity = $targetEntity;
                 $lastAlias = $alias;
 
                 continue;


### PR DESCRIPTION
In the constructor the `targetEntity` of the association is used to save already known entities but then in `buildAccessPath` it uses `currentEntity` which isn't the same. This causes duplicate joins to be created.

Now both places use the `targetEntity` of the association.