### PR TITLE
ensure different executors are used for different query builders

### DIFF
--- a/src/Target/DoctrineORM/DoctrineORM.php
+++ b/src/Target/DoctrineORM/DoctrineORM.php
@@ -45,6 +45,7 @@ class DoctrineORM extends AbstractSqlTarget
         $aliases = implode('', $context['root_aliases']);
         $entities = implode('', $context['root_entities']);
         $joined = '';
+
         /** @var Expr\Join[] $joins */
         foreach ($context['joins'] as $rootEntity => $joins) {
             foreach ($joins as $join) {

--- a/src/Target/DoctrineORM/DoctrineORM.php
+++ b/src/Target/DoctrineORM/DoctrineORM.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace RulerZ\Target\DoctrineORM;
 
+use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 
 use RulerZ\Compiler\Context;
@@ -43,8 +44,15 @@ class DoctrineORM extends AbstractSqlTarget
     {
         $aliases = implode('', $context['root_aliases']);
         $entities = implode('', $context['root_entities']);
+        $joined = '';
+        /** @var Expr\Join[] $joins */
+        foreach ($context['joins'] as $rootEntity => $joins) {
+            foreach ($joins as $join) {
+                $joined .= $join->getAlias().$join->getJoin();
+            }
+        }
 
-        return $aliases.$entities;
+        return $aliases.$entities.$joined;
     }
 
     /**

--- a/tests/spec/RulerZ/Target/DoctrineORM/DoctrineORMSpec.php
+++ b/tests/spec/RulerZ/Target/DoctrineORM/DoctrineORMSpec.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace spec\RulerZ\Target\DoctrineORM;
 
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 
@@ -123,6 +124,19 @@ class DoctrineORMSpec extends BaseTargetBehavior
                 ],
             ],
         ]);
+    }
+
+    public function it_generates_a_different_identifier_for_contexts_with_joins(Expr\Join $join)
+    {
+        $rule = 'group.name = "ADMIN" or group.name = "OWNER"';
+        $joinLessContext = $this->createContext();
+        $join->getJoin()->willReturn('test.group');
+        $join->getAlias()->willReturn('grp');
+        $contextWithJoins = $this->createContext();
+        $contextWithJoins['joins'] = ['some_root' => [$join->getWrappedObject()]];
+
+        $joinLessIdentifier = $this->getRuleIdentifierHint($rule, $joinLessContext)->getWrappedObject();
+        $this->getRuleIdentifierHint($rule, $contextWithJoins)->shouldNotReturn($joinLessIdentifier);
     }
 
     public function it_uses_the_metadata_to_detect_invalid_attribute_access()


### PR DESCRIPTION
see #107 for more detail

when the same rule is reused for several different query builders
the current identifier assumes they can use the same executor, which
now will join any determined joins from a different incompatible querybuilder
potentially joining the same alias and table again