### PR TITLE
Allow use symfony/property-access v. 5.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "php": ">=7.1",
 
         "hoa/ruler": "~2.0",
-        "symfony/property-access": "~3.0|~4.0"
+        "symfony/property-access": "~3.0|~4.0|~5.0"
     },
     "require-dev": {
         "ext-json": "*",


### PR DESCRIPTION
@K-Phoen Please, allow use package **symfony/property-access** with version 5.*, it blocks upgrade to Symfony 5