### PR TITLE
🐞 Satisfies return null instead of bool

### DIFF
--- a/src/Executor/ArrayTarget/SatisfiesTrait.php
+++ b/src/Executor/ArrayTarget/SatisfiesTrait.php
@@ -18,6 +18,6 @@ trait SatisfiesTrait
     {
         $wrappedTarget = is_array($target) ? $target : new ObjectContext($target);
 
-        return $this->execute($wrappedTarget, $operators, $parameters);
+        return (bool) $this->execute($wrappedTarget, $operators, $parameters);
     }
 }


### PR DESCRIPTION
Satisfies return null value instead of bool

The error occurs when the rule is written incorrectly, Like below:
`any-example=123`
Instead of:
`any-example = 123`